### PR TITLE
Add native Unraid notifications and improve Mover Tuning startup handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,12 +23,13 @@
 - [🤖 Telegram Bot Setup](#-telegram-bot-setup)
 - [🖥️ Discord Webhook Setup](#-discord-webhook-setup)
 - [📲 Pushover Setup](#-pushover-setup)
+- [🟩 Native Unraid Notifications](#-native-unraid-notifications)
 - [📣 Apprise Setup](#-apprise-setup)
 - [🐛 Reporting Issues](#-reporting-issues)
 - [⚖️ License](#-license)
 
 ### 📜 Description 
-This Bash script monitors the progress of the "Mover" process and sends updates to Discord, Telegram, Pushover, and/or Apprise. It provides real-time notifications on the status of the data moving process from SSD Cache to HDD Array.
+This Bash script monitors the progress of the "Mover" process and sends updates to Discord, Telegram, Pushover, Apprise, and/or native Unraid notifications. It provides real-time notifications on the status of the data moving process from SSD Cache to HDD Array.
 
 ## 📸 Images (preview) 
 <img src="https://i.imgur.com/owBzb5R.png" width="60%" alt="An example of how it looks">
@@ -85,6 +86,12 @@ Edit the script to configure the necessary settings:
 - `USE_DISCORD`: Set to `true` to enable Discord notifications.
 - `USE_PUSHOVER`: Set to `true` to enable Pushover notifications.
 - `USE_APPRISE`: Set to `true` to enable Apprise notifications.
+- `USE_UNRAID`: Set to `true` to submit notifications through Unraid's native notification system.
+- `UNRAID_NOTIFY_BIN`: Path to Unraid's native `notify` executable.
+- `UNRAID_EVENT`: Event name shown in the Unraid notification list.
+- `UNRAID_TITLE`: Subject shown by Unraid notifications.
+- `UNRAID_MOVING_MESSAGE`: Native Unraid progress-notification template; supports `{percent}`, `{remaining_data}`, `{etc}`, `{file_count}`, and `{current_file}`.
+- `UNRAID_COMPLETION_MESSAGE`: Optional native Unraid completion template.
 - `APPRISE_MODE`: Select `cli` for the local Apprise CLI or `api` for an Apprise API server.
 - `APPRISE_BIN`: Path to the local Apprise executable when using CLI mode.
 - `APPRISE_API_URL`: Base URL of the Apprise API server when using API mode.
@@ -162,13 +169,41 @@ Edit the script to configure the necessary settings:
 5. Optionally change `PUSHOVER_TITLE` to customize the notification title.
 6. Set `DRY_RUN=true` to send a test notification without monitoring Mover.
 
+### 🟩 Native Unraid Notifications
+
+Mover Status can submit progress and completion updates directly to Unraid's built-in notification subsystem. This provides notifications in the Unraid web GUI, including the notification list and browser popup/toast behavior when enabled in Unraid's notification settings.
+
+Enable it with:
+
+```bash
+USE_UNRAID=true
+UNRAID_NOTIFY_BIN="/usr/local/emhttp/webGui/scripts/notify"
+UNRAID_EVENT="Mover Status"
+UNRAID_TITLE="Mover Status"
+```
+
+Native notifications use `normal` importance and follow the notification preferences configured in Unraid. No Apprise installation is required for the local Unraid notification itself.
+
+If the **Lime Technology - Apprise** Community Applications package is installed and configured as an Unraid notification agent, the same native Unraid notification can also be forwarded through Apprise to the destinations configured in Unraid.
+
+If you enable both `USE_UNRAID=true` and `USE_APPRISE=true`, and Unraid's Apprise notification agent is also configured for the same destination, that destination may receive duplicate notifications because Mover Status is intentionally using two independent notification paths.
+
+For native Unraid notifications plus Unraid-managed Apprise forwarding, use:
+
+```bash
+USE_UNRAID=true
+USE_APPRISE=false
+```
+
+Set `DRY_RUN=true` to test the native notification without monitoring Mover.
+
 ### 📣 Apprise Setup
 
 [Apprise](https://github.com/caronc/apprise) provides a common notification interface for many different services. Mover Status supports Apprise in two modes: a local CLI and the Apprise HTTP API.
 
 On Unraid, the following Community Applications packages were used while developing and testing this integration:
 
-- **Lime Technology - Apprise** — installs the `apprise-go` CLI as `/usr/bin/apprise` and can be used with `APPRISE_MODE="cli"`.
+- **Lime Technology - Apprise** — installs the `apprise-go` CLI as `/usr/bin/apprise`, can be used with `APPRISE_MODE="cli"`, and can also act as an Unraid notification agent for native Unraid notifications.
 - **linuxserver's Repository - apprise-api (Apprise-api)** — runs an Apprise API server and can be used with `APPRISE_MODE="api"`.
 
 <p align="center">

--- a/moverStatus.sh
+++ b/moverStatus.sh
@@ -68,6 +68,7 @@ DISCORD_MOVING_MESSAGE="Moving data from SSD Cache to HDD Array.\nProgress: **{p
 PUSHOVER_MOVING_MESSAGE=$'Moving data from SSD Cache to HDD Array.\nProgress: {percent}% complete.\nRemaining data: {remaining_data}.\nEstimated completion time: {etc}.\n\nNote: Services like Plex may run slow or be unavailable during the move.'
 APPRISE_MOVING_MESSAGE=$'Moving data from SSD Cache to HDD Array.\nProgress: {percent}% complete.\nRemaining data: {remaining_data}.\nEstimated completion time: {etc}.\n\nNote: Services like Plex may run slow or be unavailable during the move.'
 UNRAID_MOVING_MESSAGE="Moving data from SSD Cache to HDD Array. Progress: {percent}% complete. Remaining data: {remaining_data}. Estimated completion time: {etc}."
+PREPARING_MESSAGE="Mover has started. Mover Tuning is preparing/scanning cache data. Progress will be available when transfer begins."
 COMPLETION_MESSAGE="Moving has been completed!"
 DISCORD_COMPLETION_MESSAGE=""                                           # If empty, falls back to COMPLETION_MESSAGE
 TELEGRAM_COMPLETION_MESSAGE=""                                          # If empty, falls back to COMPLETION_MESSAGE
@@ -1198,6 +1199,7 @@ send_notification() {
     local remaining_data=$2
     local pushover_only=${3:-false}
     local skip_pushover=${4:-false}
+    local message_override=${5:-}
     local datetime
     datetime=$(date +"%B %d (%Y) - %H:%M:%S")
     local etc_discord
@@ -1244,6 +1246,15 @@ send_notification() {
     value_message_unraid="${value_message_unraid//\{etc\}/$etc_unraid}"
     value_message_unraid="${value_message_unraid//\{file_count\}/$file_count_str}"
     value_message_unraid="${value_message_unraid//\{current_file\}/$current_file_str}"
+
+    # A preparing/start notification uses the normal transport plumbing but
+    # deliberately does not pretend that percentage data exists yet.
+    if [ -n "$message_override" ]; then
+        value_message_discord="$message_override"
+        value_message_telegram="$message_override"
+        value_message_pushover="$message_override"
+        value_message_unraid="$message_override"
+    fi
 
     local footer_text="Version: v${CURRENT_VERSION}"
     if [[ -n "${LATEST_VERSION}" && "${LATEST_VERSION}" != "${CURRENT_VERSION}" ]]; then
@@ -1348,6 +1359,36 @@ send_notification() {
         return 1
     fi
     return 0
+}
+
+# Send a one-time start notification while Mover Tuning is preparing.
+# This is informational and best-effort; normal progress/completion delivery
+# remains authoritative if a transport is temporarily unavailable.
+send_preparing_notifications() {
+    local notification_failed=false
+
+    if direct_notifications_enabled; then
+        if send_notification 0 "Calculating..." false false "$PREPARING_MESSAGE"; then
+            log "Mover preparing notification submitted to direct channels."
+        else
+            notification_failed=true
+            log "Warning: Mover preparing notification had a direct-channel delivery failure."
+        fi
+    fi
+
+    if $USE_APPRISE; then
+        local i
+        for i in "${!APPRISE_TARGETS[@]}"; do
+            if send_apprise_target "$i" "$APPRISE_TITLE" "$PREPARING_MESSAGE" "info"; then
+                log "Mover preparing notification sent to Apprise target $((i + 1))."
+            else
+                notification_failed=true
+                log "Warning: Mover preparing notification failed for Apprise target $((i + 1))."
+            fi
+        done
+    fi
+
+    ! $notification_failed
 }
 
 # Send the first percentage notification once trustworthy progress exists.
@@ -1474,8 +1515,11 @@ while true; do
 
         LAST_NOTIFIED=-1
 
-        # Do not emit a fake percentage while Mover Tuning is still preparing.
-        if [ "$DATA_SOURCE" != "preparing" ]; then
+        # While Mover Tuning is preparing, announce the run without inventing
+        # a percentage. Normal percentage notifications begin with fresh data.
+        if [ "$DATA_SOURCE" = "preparing" ]; then
+            send_preparing_notifications || true
+        else
             send_initial_notifications "$percent" "$remaining_readable"
         fi
     fi

--- a/moverStatus.sh
+++ b/moverStatus.sh
@@ -2,7 +2,7 @@
 
 # Script Metadata
 #name=Mover Status Script
-#description=This script monitors the progress of the "Mover" process and posts updates to Discord, Telegram, Pushover, and/or Apprise.
+#description=This script monitors the progress of the "Mover" process and posts updates to Discord, Telegram, Pushover, Apprise, and/or native Unraid notifications.
 #backgroundOnly=true
 #arrayStarted=true
 
@@ -10,7 +10,7 @@
 # Mover Status Script
 # ---------------------------------------------------------
 # Monitors Unraid's mover process and posts progress updates
-# to Discord, Telegram, Pushover, and/or Apprise.
+# to Discord, Telegram, Pushover, Apprise, and/or native Unraid notifications.
 #
 # Dependencies: bash, curl, jq, du, pgrep, date
 # Optional: apprise CLI when APPRISE_MODE=cli
@@ -34,6 +34,7 @@ USE_TELEGRAM=false                                                      # Enable
 USE_DISCORD=false                                                       # Enable notifications to Discord
 USE_PUSHOVER=false                                                      # Enable notifications to Pushover
 USE_APPRISE=false                                                       # Enable notifications through Apprise
+USE_UNRAID=false                                                        # Enable native Unraid notifications/toasts
 TELEGRAM_BOT_TOKEN="xxxx"                                               # Telegram bot token
 TELEGRAM_CHAT_ID="xxxx"                                                 # Telegram chat ID
 DISCORD_WEBHOOK_URL="https://discord.com/api/webhooks/xxxx/xxxx"        # Discord webhook URL
@@ -45,6 +46,9 @@ APPRISE_MODE="cli"                                                       # Appri
 APPRISE_BIN="/usr/bin/apprise"                                          # Apprise CLI executable
 APPRISE_API_URL="http://127.0.0.1:8000"                                 # Apprise API base URL when mode=api
 APPRISE_TITLE="Mover Status"                                             # Notification title for Apprise
+UNRAID_NOTIFY_BIN="/usr/local/emhttp/webGui/scripts/notify"              # Native Unraid notify executable
+UNRAID_EVENT="Mover Status"                                              # Event name shown by Unraid
+UNRAID_TITLE="Mover Status"                                              # Notification subject shown by Unraid
 APPRISE_TARGETS=(
     # "pover://USER_KEY@APP_TOKEN"
 )
@@ -63,11 +67,13 @@ TELEGRAM_MOVING_MESSAGE="Moving data from SSD Cache to HDD Array. &#10;Progress:
 DISCORD_MOVING_MESSAGE="Moving data from SSD Cache to HDD Array.\nProgress: **{percent}%** complete.\nRemaining data: {remaining_data}.\nEstimated completion time: {etc}.\n\nNote: Services like Plex may run slow or be unavailable during the move."
 PUSHOVER_MOVING_MESSAGE=$'Moving data from SSD Cache to HDD Array.\nProgress: {percent}% complete.\nRemaining data: {remaining_data}.\nEstimated completion time: {etc}.\n\nNote: Services like Plex may run slow or be unavailable during the move.'
 APPRISE_MOVING_MESSAGE=$'Moving data from SSD Cache to HDD Array.\nProgress: {percent}% complete.\nRemaining data: {remaining_data}.\nEstimated completion time: {etc}.\n\nNote: Services like Plex may run slow or be unavailable during the move.'
+UNRAID_MOVING_MESSAGE="Moving data from SSD Cache to HDD Array. Progress: {percent}% complete. Remaining data: {remaining_data}. Estimated completion time: {etc}."
 COMPLETION_MESSAGE="Moving has been completed!"
 DISCORD_COMPLETION_MESSAGE=""                                           # If empty, falls back to COMPLETION_MESSAGE
 TELEGRAM_COMPLETION_MESSAGE=""                                          # If empty, falls back to COMPLETION_MESSAGE
 PUSHOVER_COMPLETION_MESSAGE=""                                          # If empty, falls back to COMPLETION_MESSAGE
 APPRISE_COMPLETION_MESSAGE=""                                           # If empty, falls back to COMPLETION_MESSAGE
+UNRAID_COMPLETION_MESSAGE=""                                            # If empty, falls back to COMPLETION_MESSAGE
 
 # ---------------------------------------
 # Exclusion Folders: Define paths to exclude
@@ -106,7 +112,7 @@ LAST_NOTIFIED=-1
 # ---------------------------------------------------------
 
 # Check if at least one notification method is enabled
-if ! $USE_TELEGRAM && ! $USE_DISCORD && ! $USE_PUSHOVER && ! $USE_APPRISE; then
+if ! $USE_TELEGRAM && ! $USE_DISCORD && ! $USE_PUSHOVER && ! $USE_APPRISE && ! $USE_UNRAID; then
     log "Error: All notification methods are disabled. At least one must be enabled."
     exit 1
 fi
@@ -129,6 +135,13 @@ fi
 if [[ $USE_PUSHOVER == true ]]; then
     if [ -z "$PUSHOVER_APP_TOKEN" ] || [ "$PUSHOVER_APP_TOKEN" = "xxxx" ] || [ -z "$PUSHOVER_USER_KEY" ] || [ "$PUSHOVER_USER_KEY" = "xxxx" ]; then
         log "Error: Pushover settings not configured correctly."
+        exit 1
+    fi
+fi
+
+if [[ $USE_UNRAID == true ]]; then
+    if [ ! -x "$UNRAID_NOTIFY_BIN" ]; then
+        log "Error: Unraid notify executable is not available at: $UNRAID_NOTIFY_BIN"
         exit 1
     fi
 fi
@@ -265,7 +278,7 @@ send_apprise_target() {
 
 # True when at least one built-in direct notification channel is enabled.
 direct_notifications_enabled() {
-    $USE_TELEGRAM || $USE_DISCORD || $USE_PUSHOVER
+    $USE_TELEGRAM || $USE_DISCORD || $USE_PUSHOVER || $USE_UNRAID
 }
 
 # Validate DU_POLL_INTERVAL is a positive integer
@@ -308,6 +321,7 @@ if $DRY_RUN; then
     dry_run_etc_telegram="01/01/2099, 12pm"
     dry_run_etc_pushover="01/01/2099, 12pm"
     dry_run_etc_apprise="01/01/2099, 12pm"
+    dry_run_etc_unraid="01/01/2099, 12pm"
 
     # Simulate file info if available
     dry_run_file_count=""
@@ -360,6 +374,12 @@ if $DRY_RUN; then
     dry_run_value_message_apprise="${dry_run_value_message_apprise//\{current_file\}/$dry_run_current_file}"
     dry_run_value_message_apprise+=$'\n\n'"${footer_text}"
 
+    dry_run_value_message_unraid="${UNRAID_MOVING_MESSAGE//\{percent\}/$dry_run_percent}"
+    dry_run_value_message_unraid="${dry_run_value_message_unraid//\{remaining_data\}/$dry_run_remaining_data}"
+    dry_run_value_message_unraid="${dry_run_value_message_unraid//\{etc\}/$dry_run_etc_unraid}"
+    dry_run_value_message_unraid="${dry_run_value_message_unraid//\{file_count\}/$dry_run_file_count}"
+    dry_run_value_message_unraid="${dry_run_value_message_unraid//\{current_file\}/$dry_run_current_file}"
+
     # Send test notifications
     if $USE_TELEGRAM; then
         log "Sending test notification to Telegram..."
@@ -374,6 +394,18 @@ if $DRY_RUN; then
         log "Sending test notification to Pushover..."
         if ! send_pushover "$dry_run_value_message_pushover"; then
             log "Error: Pushover dry-run notification was not delivered."
+            exit 1
+        fi
+    fi
+
+    if $USE_UNRAID; then
+        log "Sending test notification through native Unraid notifications..."
+        if ! "$UNRAID_NOTIFY_BIN" \
+            -e "$UNRAID_EVENT" \
+            -s "$UNRAID_TITLE" \
+            -d "$dry_run_value_message_unraid" \
+            -i normal; then
+            log "Error: Native Unraid dry-run notification could not be submitted."
             exit 1
         fi
     fi
@@ -826,7 +858,7 @@ format_speed() {
 
 # Build rich completion message with all available stats
 # Sets COMPLETION_SUMMARY_DISCORD, COMPLETION_SUMMARY_TELEGRAM, COMPLETION_SUMMARY_PUSHOVER,
-# and COMPLETION_SUMMARY_APPRISE
+# COMPLETION_SUMMARY_APPRISE, and COMPLETION_SUMMARY_UNRAID
 build_completion_summary() {
     local end_time duration avg_speed_val
     end_time=$(date +%s)
@@ -879,6 +911,14 @@ build_completion_summary() {
     apprise_msg="${apprise_msg//\{duration\}/$duration_str}"
     apprise_msg="${apprise_msg//\{avg_speed\}/$avg_speed_str}"
     COMPLETION_SUMMARY_APPRISE="$apprise_msg"
+
+    # Build native Unraid completion message
+    local unraid_msg="${UNRAID_COMPLETION_MESSAGE:-$COMPLETION_MESSAGE}"
+    unraid_msg="${unraid_msg//\{total_moved\}/$total_moved_str}"
+    unraid_msg="${unraid_msg//\{file_count\}/$file_count_str}"
+    unraid_msg="${unraid_msg//\{duration\}/$duration_str}"
+    unraid_msg="${unraid_msg//\{avg_speed\}/$avg_speed_str}"
+    COMPLETION_SUMMARY_UNRAID="$unraid_msg"
 }
 
 # Function to convert bytes to human-readable format
@@ -933,7 +973,7 @@ calculate_etc() {
 
         if [[ $platform == "discord" ]]; then
             echo "<t:${completion_time_estimate}:R>"
-        elif [[ $platform == "telegram" || $platform == "pushover" || $platform == "apprise" ]]; then
+        elif [[ $platform == "telegram" || $platform == "pushover" || $platform == "apprise" || $platform == "unraid" ]]; then
             date -d "@${completion_time_estimate}" +"%H:%M on %b %d (%Z)"
         fi
     else
@@ -1118,6 +1158,8 @@ send_notification() {
     etc_telegram=$(calculate_etc "$percent" "telegram")
     local etc_pushover
     etc_pushover=$(calculate_etc "$percent" "pushover")
+    local etc_unraid
+    etc_unraid=$(calculate_etc "$percent" "unraid")
 
     # Prepare file info placeholders
     local file_count_str=""
@@ -1149,6 +1191,12 @@ send_notification() {
     value_message_pushover="${value_message_pushover//\{file_count\}/$file_count_str}"
     value_message_pushover="${value_message_pushover//\{current_file\}/$current_file_str}"
 
+    local value_message_unraid="${UNRAID_MOVING_MESSAGE//\{percent\}/$percent}"
+    value_message_unraid="${value_message_unraid//\{remaining_data\}/$remaining_data}"
+    value_message_unraid="${value_message_unraid//\{etc\}/$etc_unraid}"
+    value_message_unraid="${value_message_unraid//\{file_count\}/$file_count_str}"
+    value_message_unraid="${value_message_unraid//\{current_file\}/$current_file_str}"
+
     local footer_text="Version: v${CURRENT_VERSION}"
     if [[ -n "${LATEST_VERSION}" && "${LATEST_VERSION}" != "${CURRENT_VERSION}" ]]; then
         footer_text+=" (update available)"
@@ -1163,6 +1211,7 @@ send_notification() {
         value_message_discord="$COMPLETION_SUMMARY_DISCORD"
         value_message_telegram="$COMPLETION_SUMMARY_TELEGRAM"
         value_message_pushover="$COMPLETION_SUMMARY_PUSHOVER"
+        value_message_unraid="$COMPLETION_SUMMARY_UNRAID"
         color=65280  # Green for completion
     else
         if [ "$percent" -le 34 ]; then
@@ -1190,6 +1239,21 @@ send_notification() {
         response=$(curl -s -H "Content-Type: application/json" -X POST -d "$json_payload" "https://api.telegram.org/bot$TELEGRAM_BOT_TOKEN/sendMessage")
         if $ENABLE_DEBUG; then
             log "Telegram response: $response"
+        fi
+    fi
+
+    if ! $pushover_only && $USE_UNRAID; then
+        if $ENABLE_DEBUG; then
+            log "Submitting native Unraid notification: event='$UNRAID_EVENT', subject='$UNRAID_TITLE', description='$value_message_unraid'"
+        fi
+        if ! "$UNRAID_NOTIFY_BIN" \
+            -e "$UNRAID_EVENT" \
+            -s "$UNRAID_TITLE" \
+            -d "$value_message_unraid" \
+            -i normal; then
+            # Native notify is a local handoff. Unraid manages browser/email/agent
+            # delivery downstream, so it is deliberately not tied to Pushover retries.
+            log "Warning: Native Unraid notification could not be submitted."
         fi
     fi
 
@@ -1437,7 +1501,7 @@ while true; do
             if direct_notifications_enabled; then
                 if [[ "$pushover_retry_pending" == true ]]; then
                     # Pushover is already pending, so send only to the healthy direct channels.
-                    if $USE_TELEGRAM || $USE_DISCORD; then
+                    if $USE_TELEGRAM || $USE_DISCORD || $USE_UNRAID; then
                         send_notification "$percent" "$remaining_readable" false true
                         log "Direct notification attempt completed for $percent% on non-Pushover channels."
                     fi
@@ -1492,7 +1556,7 @@ done
 
 # Mover Status Script
 # <https://github.com/engels74/mover-status>
-# This script monitors the progress of the "Mover" process and posts updates to Discord, Telegram, Pushover, and/or Apprise.
+# This script monitors the progress of the "Mover" process and posts updates to Discord, Telegram, Pushover, Apprise, and/or native Unraid notifications.
 # Copyright (C) 2024 - engels74
 #
 # This program is free software: you can redistribute it and/or modify

--- a/moverStatus.sh
+++ b/moverStatus.sh
@@ -498,7 +498,7 @@ STATE_DIR="/tmp/mover-status"
 STATE_FILE="${STATE_DIR}/state"
 LAST_RUN_FILE="${STATE_DIR}/last-run"
 
-# Global data source identifier: "mover_ini" or "du_polling"
+# Global data source identifier: "preparing", "mover_ini", or "du_polling"
 DATA_SOURCE=""
 
 # Progress globals (set by get_progress)
@@ -521,11 +521,50 @@ INI_REMAIN_FILES=0
 INI_CURRENT_FILE=""
 INI_ACTION=""
 
-# Detect whether mover.ini is available and usable
+# True only when mover.ini belongs to the currently running mover operation.
+# A previous Mover Tuning run can leave mover.ini behind indefinitely.
+mover_ini_is_current() {
+    [ -f "$MOVER_INI_PATH" ] || return 1
+    [ -n "$mover_start_time" ] || return 1
+
+    local mod_time total_line remain_line total remain
+    mod_time=$(stat -c %Y "$MOVER_INI_PATH" 2>/dev/null) || return 1
+    [ "$mod_time" -ge "$mover_start_time" ] || return 1
+
+    # Require a complete, sane byte snapshot before trusting a newly written file.
+    total_line=$(grep -m1 '^TotalToSecondary=' "$MOVER_INI_PATH" 2>/dev/null) || return 1
+    remain_line=$(grep -m1 '^RemainToSecondary=' "$MOVER_INI_PATH" 2>/dev/null) || return 1
+    total="${total_line#*=}"
+    remain="${remain_line#*=}"
+    total="${total%\"}"
+    total="${total#\"}"
+    remain="${remain%\"}"
+    remain="${remain#\"}"
+
+    [[ "$total" =~ ^[0-9]+$ ]] || return 1
+    [[ "$remain" =~ ^[0-9]+$ ]] || return 1
+    [ "$remain" -le "$total" ]
+}
+
+# Detect whether current-run mover.ini data is available.
+# Mover Tuning may spend significant time preparing/scanning before it writes
+# progress for the current run; do not fall back to an expensive second du scan.
 detect_data_source() {
-    if [ -f "$MOVER_INI_PATH" ] && grep -q "TotalToSecondary" "$MOVER_INI_PATH" 2>/dev/null; then
+    if mover_ini_is_current; then
         DATA_SOURCE="mover_ini"
-        log "Data source: mover.ini (Mover Tuning plugin detected)"
+        log "Data source: mover.ini (current Mover Tuning run)"
+    elif pgrep -x "age_mover" > /dev/null 2>&1; then
+        DATA_SOURCE="preparing"
+
+        if [ -f "$MOVER_INI_PATH" ]; then
+            local ini_mtime
+            ini_mtime=$(stat -c %Y "$MOVER_INI_PATH" 2>/dev/null || true)
+            if [ -n "$ini_mtime" ] && [ -n "$mover_start_time" ] && [ "$ini_mtime" -lt "$mover_start_time" ]; then
+                log "Ignoring stale mover.ini from $(date -d "@$ini_mtime" '+%Y-%m-%d %H:%M:%S'); current mover started at $(date -d "@$mover_start_time" '+%Y-%m-%d %H:%M:%S')."
+            fi
+        fi
+
+        log "Mover Tuning is preparing/scanning; waiting for current-run progress data."
     else
         DATA_SOURCE="du_polling"
         log "Data source: du polling (standard mover)"
@@ -577,7 +616,16 @@ read_mover_ini() {
 
 # Unified progress reader — sets PROGRESS_* globals from either data source
 get_progress() {
-    if [ "$DATA_SOURCE" = "mover_ini" ]; then
+    if [ "$DATA_SOURCE" = "preparing" ]; then
+        PROGRESS_PERCENT=0
+        PROGRESS_REMAINING_BYTES=0
+        PROGRESS_MOVED_BYTES=0
+        PROGRESS_TOTAL_BYTES=0
+        PROGRESS_FILE_COUNT=""
+        PROGRESS_REMAIN_FILES=""
+        PROGRESS_CURRENT_FILE=""
+        return 0
+    elif [ "$DATA_SOURCE" = "mover_ini" ]; then
         read_mover_ini || return 1
 
         PROGRESS_TOTAL_BYTES="$INI_TOTAL_TO_SECONDARY"
@@ -1302,6 +1350,31 @@ send_notification() {
     return 0
 }
 
+# Send the first percentage notification once trustworthy progress exists.
+send_initial_notifications() {
+    local percent=$1
+    local remaining_readable=$2
+
+    if direct_notifications_enabled; then
+        if send_notification "$percent" "$remaining_readable"; then
+            log "Initial direct notification attempt completed at ${percent}%."
+        else
+            log "Warning: Initial direct notification had a delivery failure; Pushover will be retried."
+            pushover_retry_pending=true
+            pending_percent="$percent"
+            pending_remaining="$remaining_readable"
+        fi
+    fi
+
+    if $USE_APPRISE; then
+        if ! send_apprise_progress "$percent" "$remaining_readable"; then
+            log "Warning: One or more initial Apprise targets are pending retry."
+        fi
+    fi
+
+    LAST_NOTIFIED=$((percent / NOTIFICATION_INCREMENT * NOTIFICATION_INCREMENT))
+}
+
 # Initialize state directory for crash recovery
 init_state_dir
 
@@ -1317,12 +1390,13 @@ while true; do
 
     log "Mover process found, starting monitoring..."
 
-    # Detect data source (mover.ini vs du polling)
-    detect_data_source
-
-    # Get mover PID for state tracking
+    # Get mover identity before choosing a progress source so stale mover.ini
+    # from a previous Mover Tuning run can be rejected.
     mover_pid=$(get_mover_pid) || mover_pid=""
     mover_start_time=$(get_mover_start_time "$mover_pid") || mover_start_time=""
+
+    # Detect data source (preparing vs current mover.ini vs du polling)
+    detect_data_source
 
     # Capture initial excluded size (used for consistent total adjustment)
     initial_excluded_size=0
@@ -1353,6 +1427,8 @@ while true; do
         if [ "$DATA_SOURCE" = "mover_ini" ]; then
             get_progress
             initial_size="$PROGRESS_TOTAL_BYTES"
+        elif [ "$DATA_SOURCE" = "preparing" ]; then
+            initial_size=0
         else
             initial_size=$(du -sb "$CACHE_PATH" | cut -f1)
             initial_size=$((initial_size - initial_excluded_size))
@@ -1361,14 +1437,23 @@ while true; do
             fi
         fi
 
-        initial_readable=$(human_readable "$initial_size")
-        log "Initial total size of data: $initial_readable"
+        if [ "$DATA_SOURCE" = "preparing" ]; then
+            initial_readable="Calculating..."
+            log "Initial total size unavailable while Mover Tuning is preparing."
+        else
+            initial_readable=$(human_readable "$initial_size")
+            log "Initial total size of data: $initial_readable"
+        fi
 
         start_time=$(date +%s)
         log "Monitoring started at: $(date -d "@$start_time" '+%Y-%m-%d %H:%M:%S')"
 
         # Check for late-join (mover already running before script started)
-        if [ "$DATA_SOURCE" = "mover_ini" ] && [ "$PROGRESS_MOVED_BYTES" -gt 0 ]; then
+        if [ "$DATA_SOURCE" = "preparing" ]; then
+            monitoring_start_bytes=0
+            percent=0
+            remaining_readable="Calculating..."
+        elif [ "$DATA_SOURCE" = "mover_ini" ] && [ "$PROGRESS_MOVED_BYTES" -gt 0 ]; then
             monitoring_start_bytes="$PROGRESS_MOVED_BYTES"
             log "Late join detected — mover already $(( PROGRESS_PERCENT ))% complete (using mover.ini data, baseline: $(human_readable "$monitoring_start_bytes"))"
             percent="$PROGRESS_PERCENT"
@@ -1389,31 +1474,36 @@ while true; do
 
         LAST_NOTIFIED=-1
 
-        if direct_notifications_enabled; then
-            if send_notification "$percent" "$remaining_readable"; then
-                log "Initial direct notification attempt completed at ${percent}%."
-            else
-                log "Warning: Initial direct notification had a delivery failure; Pushover will be retried."
-                pushover_retry_pending=true
-                pending_percent="$percent"
-                pending_remaining="$remaining_readable"
-            fi
+        # Do not emit a fake percentage while Mover Tuning is still preparing.
+        if [ "$DATA_SOURCE" != "preparing" ]; then
+            send_initial_notifications "$percent" "$remaining_readable"
         fi
-
-        if $USE_APPRISE; then
-            if ! send_apprise_progress "$percent" "$remaining_readable"; then
-                log "Warning: One or more initial Apprise targets are pending retry."
-            fi
-        fi
-
-        # Advance the normal notification schedule independently of transport retries.
-        LAST_NOTIFIED=$((percent / NOTIFICATION_INCREMENT * NOTIFICATION_INCREMENT))
     fi
 
     # Monitor the progress
     last_du_time=0
     while true; do
         current_time=$(date +%s)
+
+        # Switch to mover.ini as soon as Mover Tuning writes current-run data.
+        if [ "$DATA_SOURCE" = "preparing" ] && is_mover_running && mover_ini_is_current; then
+            DATA_SOURCE="mover_ini"
+            log "Fresh mover.ini detected; switching to Mover Tuning progress tracking."
+
+            get_progress
+            initial_size="$PROGRESS_TOTAL_BYTES"
+            remaining_readable=$(human_readable "$PROGRESS_REMAINING_BYTES")
+            percent="$PROGRESS_PERCENT"
+
+            monitoring_start_bytes="$PROGRESS_MOVED_BYTES"
+            if [ "$monitoring_start_bytes" -gt 0 ]; then
+                log "Mover already ${percent}% complete when current-run progress became available."
+            fi
+
+            send_initial_notifications "$percent" "$remaining_readable"
+            save_state
+            last_du_time=$current_time
+        fi
 
         # Only recalculate progress when DU_POLL_INTERVAL has passed
         if [ $((current_time - last_du_time)) -ge "$DU_POLL_INTERVAL" ]; then
@@ -1436,6 +1526,13 @@ while true; do
         # Check if the mover process is still running
         if ! is_mover_running; then
             log "Mover process is no longer running."
+
+            # If Mover Tuning produced current-run data just as the wrapper exited,
+            # use it for final stats without emitting a late progress notification.
+            if [ "$DATA_SOURCE" = "preparing" ] && mover_ini_is_current; then
+                DATA_SOURCE="mover_ini"
+                log "Current-run mover.ini became available at completion; using it for final stats."
+            fi
 
             # Final progress read — captures mover.ini final state before it goes stale
             get_progress

--- a/moverStatus.sh
+++ b/moverStatus.sh
@@ -522,29 +522,65 @@ INI_REMAIN_FILES=0
 INI_CURRENT_FILE=""
 INI_ACTION=""
 
-# True only when mover.ini belongs to the currently running mover operation.
-# A previous Mover Tuning run can leave mover.ini behind indefinitely.
-mover_ini_is_current() {
+# Load one stable, complete mover.ini snapshot into INI_* globals.
+# Mover Tuning rewrites this file in place, so progress must never be
+# calculated from a file that changed while it was being read.
+load_mover_ini_snapshot() {
     [ -f "$MOVER_INI_PATH" ] || return 1
     [ -n "$mover_start_time" ] || return 1
 
-    local mod_time total_line remain_line total remain
+    local before after mod_time snapshot
+    before=$(stat -c '%i:%y:%s' "$MOVER_INI_PATH" 2>/dev/null) || return 1
     mod_time=$(stat -c %Y "$MOVER_INI_PATH" 2>/dev/null) || return 1
     [ "$mod_time" -ge "$mover_start_time" ] || return 1
 
-    # Require a complete, sane byte snapshot before trusting a newly written file.
-    total_line=$(grep -m1 '^TotalToSecondary=' "$MOVER_INI_PATH" 2>/dev/null) || return 1
-    remain_line=$(grep -m1 '^RemainToSecondary=' "$MOVER_INI_PATH" 2>/dev/null) || return 1
-    total="${total_line#*=}"
-    remain="${remain_line#*=}"
-    total="${total%\"}"
-    total="${total#\"}"
-    remain="${remain%\"}"
-    remain="${remain#\"}"
+    # Capture the whole small file using Bash itself, then verify that the
+    # inode/mtime/size did not change while it was being read.
+    snapshot=$(<"$MOVER_INI_PATH")
+    after=$(stat -c '%i:%y:%s' "$MOVER_INI_PATH" 2>/dev/null) || return 1
+    [ "$before" = "$after" ] || return 1
 
+    local total="" remain="" total_files="" remain_files=""
+    local current_file="" action="" key value
+    while IFS='=' read -r key value; do
+        value="${value%\"}"
+        value="${value#\"}"
+        case "$key" in
+            TotalToSecondary)       total="$value" ;;
+            RemainToSecondary)      remain="$value" ;;
+            TotalFilesToSecondary)  total_files="$value" ;;
+            RemainFilesToSecondary) remain_files="$value" ;;
+            File)                    current_file="$value" ;;
+            Action)                  action="$value" ;;
+        esac
+    done <<< "$snapshot"
+
+    # Byte counters are mandatory for trustworthy progress.
     [[ "$total" =~ ^[0-9]+$ ]] || return 1
     [[ "$remain" =~ ^[0-9]+$ ]] || return 1
-    [ "$remain" -le "$total" ]
+    [ "$remain" -le "$total" ] || return 1
+
+    # File counters are optional, but if either appears require a complete,
+    # sane pair from the same stable snapshot.
+    if [ -n "$total_files" ] || [ -n "$remain_files" ]; then
+        [[ "$total_files" =~ ^[0-9]+$ ]] || return 1
+        [[ "$remain_files" =~ ^[0-9]+$ ]] || return 1
+        [ "$remain_files" -le "$total_files" ] || return 1
+    fi
+
+    # Publish only after the snapshot has passed every validation check.
+    INI_TOTAL_TO_SECONDARY="$total"
+    INI_REMAIN_TO_SECONDARY="$remain"
+    INI_TOTAL_FILES="$total_files"
+    INI_REMAIN_FILES="$remain_files"
+    INI_CURRENT_FILE="$current_file"
+    INI_ACTION="$action"
+}
+
+# True only when mover.ini belongs to the currently running mover operation
+# and contains one stable, complete snapshot.
+mover_ini_is_current() {
+    load_mover_ini_snapshot
 }
 
 # Detect whether current-run mover.ini data is available.
@@ -572,28 +608,12 @@ detect_data_source() {
     fi
 }
 
-# Parse mover.ini into INI_* globals
+# Parse one validated mover.ini snapshot into INI_* globals.
 read_mover_ini() {
-    if [ ! -f "$MOVER_INI_PATH" ]; then
-        log "Warning: mover.ini not found at $MOVER_INI_PATH"
+    if ! load_mover_ini_snapshot; then
+        log "Warning: mover.ini is stale, incomplete, or changed while being read; keeping the last valid progress snapshot."
         return 1
     fi
-
-    local key value
-    # shellcheck disable=SC2034
-    while IFS='=' read -r key value; do
-        # Remove surrounding quotes from value
-        value="${value%\"}"
-        value="${value#\"}"
-        case "$key" in
-            TotalToSecondary)  INI_TOTAL_TO_SECONDARY="$value" ;;
-            RemainToSecondary) INI_REMAIN_TO_SECONDARY="$value" ;;
-            TotalFilesToSecondary)  INI_TOTAL_FILES="$value" ;;
-            RemainFilesToSecondary) INI_REMAIN_FILES="$value" ;;
-            File)   INI_CURRENT_FILE="$value" ;;
-            Action) INI_ACTION="$value" ;;
-        esac
-    done < "$MOVER_INI_PATH"
 
     # Staleness check: warn if file hasn't been modified in >3x DU_POLL_INTERVAL
     local mod_time current_time age stale_threshold
@@ -1285,6 +1305,7 @@ send_notification() {
     # Send the notifications
     log "Sending notification..."
     local notification_failed=false
+    PUSHOVER_DELIVERY_FAILED=false
     if ! $pushover_only && $USE_TELEGRAM; then
         local json_payload
         json_payload=$(jq -n \
@@ -1310,9 +1331,10 @@ send_notification() {
             -s "$UNRAID_TITLE" \
             -d "$value_message_unraid" \
             -i normal; then
-            # Native notify is a local handoff. Unraid manages browser/email/agent
-            # delivery downstream, so it is deliberately not tied to Pushover retries.
+            # Native notify is a local handoff. Surface a failed handoff to the
+            # caller, but do not incorrectly route it through Pushover retries.
             log "Warning: Native Unraid notification could not be submitted."
+            notification_failed=true
         fi
     fi
 
@@ -1322,29 +1344,42 @@ send_notification() {
         fi
         if ! send_pushover "$value_message_pushover"; then
             notification_failed=true
+            PUSHOVER_DELIVERY_FAILED=true
         fi
     fi
 
     if ! $pushover_only && $USE_DISCORD; then
-        local notification_data='{
-            "username": "'"$DISCORD_NAME_OVERRIDE"'",
-            "content": null,
-            "embeds": [
-                {
-                    "title": "Mover: Moving Data",
-                    "color": '"$color"',
-                    "fields": [
-                        {
-                            "name": "'"$datetime"'",
-                            "value": "'"${value_message_discord}"'"
-                        }
-                    ],
-                    "footer": {
-                        "text": "'"$footer_text"'"
+        # Existing Discord templates use literal \n sequences because the old
+        # payload was hand-built JSON. Convert only that legacy newline marker;
+        # jq handles all JSON escaping. An override is already plain text.
+        local discord_field_value="$value_message_discord"
+        if [ -z "$message_override" ]; then
+            discord_field_value=${discord_field_value//\\n/$'\n'}
+        fi
+
+        local notification_data
+        notification_data=$(jq -cn \
+            --arg username "$DISCORD_NAME_OVERRIDE" \
+            --arg field_name "$datetime" \
+            --arg field_value "$discord_field_value" \
+            --arg footer "$footer_text" \
+            --argjson color "$color" \
+            '{
+                username: $username,
+                content: null,
+                embeds: [{
+                    title: "Mover: Moving Data",
+                    color: $color,
+                    fields: [{
+                        name: $field_name,
+                        value: $field_value
+                    }],
+                    footer: {
+                        text: $footer
                     }
-                }
-            ]
-        }'
+                }]
+            }')
+
         if $ENABLE_DEBUG; then
             log "Preparing to send to Discord: $notification_data"
         fi
@@ -1400,10 +1435,13 @@ send_initial_notifications() {
         if send_notification "$percent" "$remaining_readable"; then
             log "Initial direct notification attempt completed at ${percent}%."
         else
-            log "Warning: Initial direct notification had a delivery failure; Pushover will be retried."
-            pushover_retry_pending=true
-            pending_percent="$percent"
-            pending_remaining="$remaining_readable"
+            log "Warning: Initial direct notification had a delivery failure."
+            if [[ "$PUSHOVER_DELIVERY_FAILED" == true ]]; then
+                log "Pushover will be retried."
+                pushover_retry_pending=true
+                pending_percent="$percent"
+                pending_remaining="$remaining_readable"
+            fi
         fi
     fi
 
@@ -1544,7 +1582,12 @@ while true; do
                 log "Mover already ${percent}% complete when current-run progress became available."
             fi
 
-            send_initial_notifications "$percent" "$remaining_readable"
+            if [ "$percent" -gt 0 ]; then
+                send_initial_notifications "$percent" "$remaining_readable"
+            else
+                log "Fresh mover.ini reports 0%; preparing notification already announced this run, suppressing duplicate 0% notification."
+                LAST_NOTIFIED=0
+            fi
             save_state
             last_du_time=$current_time
         fi
@@ -1599,8 +1642,16 @@ while true; do
                     log "Final direct notification attempt completed."
                     standard_completion_done=true
                 else
-                    log "Warning: Final direct notification had a delivery failure; Pushover will be retried."
-                    completion_retry_pending=true
+                    log "Warning: Final direct notification had a delivery failure."
+                    if [[ "$PUSHOVER_DELIVERY_FAILED" == true ]]; then
+                        log "Final Pushover notification will be retried."
+                        completion_retry_pending=true
+                    else
+                        # Native Unraid submission is a one-shot local handoff.
+                        # The failure has been surfaced; avoid duplicating healthy
+                        # direct channels by resending the whole completion message.
+                        standard_completion_done=true
+                    fi
                 fi
             fi
 
@@ -1643,8 +1694,11 @@ while true; do
                 if [[ "$pushover_retry_pending" == true ]]; then
                     # Pushover is already pending, so send only to the healthy direct channels.
                     if $USE_TELEGRAM || $USE_DISCORD || $USE_UNRAID; then
-                        send_notification "$percent" "$remaining_readable" false true
-                        log "Direct notification attempt completed for $percent% on non-Pushover channels."
+                        if send_notification "$percent" "$remaining_readable" false true; then
+                            log "Direct notification attempt completed for $percent% on non-Pushover channels."
+                        else
+                            log "Warning: A non-Pushover direct notification failed for $percent% completion."
+                        fi
                     fi
 
                     # Coalesce the pending Pushover retry to the newest progress update.
@@ -1654,10 +1708,13 @@ while true; do
                 elif send_notification "$percent" "$remaining_readable"; then
                     log "Direct notification attempt completed for $percent% completion."
                 else
-                    log "Warning: Direct notification for $percent% had a delivery failure; Pushover will be retried."
-                    pushover_retry_pending=true
-                    pending_percent="$percent"
-                    pending_remaining="$remaining_readable"
+                    log "Warning: Direct notification for $percent% had a delivery failure."
+                    if [[ "$PUSHOVER_DELIVERY_FAILED" == true ]]; then
+                        log "Pushover will be retried."
+                        pushover_retry_pending=true
+                        pending_percent="$percent"
+                        pending_remaining="$remaining_readable"
+                    fi
                 fi
             fi
 


### PR DESCRIPTION
## Summary

Adds native Unraid notification support and improves startup/progress handling when the Mover Tuning plugin is installed.

The Mover Tuning changes address a real case where a newly started Mover run could initially read stale `mover.ini` data from the previous run and report misleading progress while Mover Tuning was still preparing/scanning cache data.

The three changes are kept as separate commits:

1. Add native Unraid notification support
2. Ignore stale Mover Tuning progress data
3. Notify when Mover Tuning starts preparing

## Native Unraid notifications

Adds an optional native Unraid notification path using:

`/usr/local/emhttp/webGui/scripts/notify`

Configuration includes:

- `USE_UNRAID`
- `UNRAID_NOTIFY_BIN`
- `UNRAID_EVENT`
- `UNRAID_TITLE`
- `UNRAID_MOVING_MESSAGE`
- `UNRAID_COMPLETION_MESSAGE`

Native notifications participate alongside the existing Telegram, Discord, Pushover, and Apprise transports.

The README also documents how native Unraid notifications can be forwarded through the Lime Technology Apprise notification agent, including the possibility of duplicate delivery if both direct Apprise and Unraid-managed Apprise forwarding target the same destination.

## Mover Tuning startup handling

When Mover Tuning starts, its existing `mover.ini` may still contain data from the previous Mover run while `age_mover` performs its initial scan.

The updated logic:

- Validates that `mover.ini` belongs to the current Mover run
- Rejects stale or incomplete progress data
- Avoids reporting misleading 99/100% progress from stale state
- Treats the Mover Tuning pre-scan as a distinct preparing state
- Avoids running a competing `du` scan while Mover Tuning is already preparing
- Transitions to normal `mover.ini` progress once fresh data becomes available
- Sends a one-time notification that Mover has started and Mover Tuning is preparing/scanning

## Testing

Tested on Unraid with Mover Tuning installed.

### Native Unraid notifications

- Confirmed direct native Unraid notification submission
- Confirmed native-only `DRY_RUN` succeeds
- Tested synthetic progress lifecycle through native notifications
- Tested completion notification
- Tested native notifications remaining healthy while Pushover delivery was intentionally broken
- Confirmed invalid native notify executable path fails validation
- Confirmed native notifications use Unraid's configured notification subsystem and normal importance

### Mover Tuning startup/freshness

Tested stale and current `mover.ini` scenarios, including:

- Stale previous-run `mover.ini` rejected during preparation
- No false 99/100% progress notification from stale data
- Fresh `mover.ini` transition from preparing to active progress
- Incomplete/current `mover.ini` rejected until usable
- Late join with already-current valid `mover.ini`
- Preparing → transfer → completion lifecycle
- Preparing → no-op completion lifecycle
- One-time preparing notification without a duplicate 0% notification

Also validated on a real Unraid Mover run: the script detected Mover Tuning's preparation/scanning phase and delivered the startup/preparing notification without reporting bogus percentage progress.

### Regression / validation

- Final `moverStatus.sh` matches the previously tested combined native-Unraid/Mover-Tuning branch
- `bash -n moverStatus.sh` passes
- `git diff --check` passes
- PR is based on current upstream `main`, including the previously merged Pushover and Apprise support

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds native Unraid notifications, keeps the script from reporting stale Mover Tuning progress at startup, and narrows notification retry behavior to Pushover only.

**Native Unraid notifications**
- Sends progress and completion through Unraid's `notify` script alongside Telegram, Discord, Pushover, and Apprise, gated by new `UNRAID_*` options.
- Enabling `USE_UNRAID` with `USE_APPRISE` can duplicate delivery when Unraid's Apprise agent forwards to the same destination.

**Mover Tuning startup and delivery handling**
- Waits in a preparing state while Mover Tuning scans, ignoring `mover.ini` from the previous run, sends a one-time start notification, and switches to normal progress when fresh data appears.
- Delivery failures now retry Pushover only; native Unraid handoff failures are logged as warnings, and Discord payloads are built with `jq` to avoid escaping issues.

<sup>Written for commit 75f72fda647ba80dd72a0d03036075dd6139b598. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/engels74/mover-status/pull/29?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

