### PR TITLE
refactor: restore a clean shellcheck run

### DIFF
--- a/moverStatus.sh
+++ b/moverStatus.sh
@@ -1086,8 +1086,8 @@ init_apprise_retry_state() {
 
     local i
     for i in "${!APPRISE_TARGETS[@]}"; do
-        apprise_progress_pending[$i]=false
-        apprise_completion_pending[$i]=false
+        apprise_progress_pending[i]=false
+        apprise_completion_pending[i]=false
     done
 }
 
@@ -1126,7 +1126,7 @@ send_apprise_progress() {
         if send_apprise_target "$i" "$APPRISE_TITLE" "$APPRISE_CURRENT_MESSAGE" "info"; then
             log "Apprise target $((i + 1)) notification sent for ${percent}% completion."
         else
-            apprise_progress_pending[$i]=true
+            apprise_progress_pending[i]=true
             log "Warning: Apprise target $((i + 1)) will be retried."
         fi
     done
@@ -1157,7 +1157,7 @@ retry_apprise_progress() {
         fi
 
         if send_apprise_target "$i" "$APPRISE_TITLE" "$APPRISE_CURRENT_MESSAGE" "info"; then
-            apprise_progress_pending[$i]=false
+            apprise_progress_pending[i]=false
             log "Apprise target $((i + 1)) retry succeeded for ${apprise_pending_percent}% completion."
         else
             log "Warning: Apprise target $((i + 1)) retry failed; will retry again."
@@ -1181,10 +1181,10 @@ start_apprise_completion() {
 
     for i in "${!APPRISE_TARGETS[@]}"; do
         if send_apprise_target "$i" "$APPRISE_TITLE" "$apprise_completion_message" "success"; then
-            apprise_completion_pending[$i]=false
+            apprise_completion_pending[i]=false
             log "Final Apprise notification sent to target $((i + 1))."
         else
-            apprise_completion_pending[$i]=true
+            apprise_completion_pending[i]=true
             log "Warning: Final Apprise notification to target $((i + 1)) will be retried."
         fi
     done
@@ -1201,7 +1201,7 @@ retry_apprise_completion() {
         fi
 
         if send_apprise_target "$i" "$APPRISE_TITLE" "$apprise_completion_message" "success"; then
-            apprise_completion_pending[$i]=false
+            apprise_completion_pending[i]=false
             log "Final Apprise notification retry succeeded for target $((i + 1))."
         else
             log "Warning: Final Apprise notification retry failed for target $((i + 1)); will retry again."

--- a/moverStatus.sh
+++ b/moverStatus.sh
@@ -520,7 +520,6 @@ INI_REMAIN_TO_SECONDARY=0
 INI_TOTAL_FILES=0
 INI_REMAIN_FILES=0
 INI_CURRENT_FILE=""
-INI_ACTION=""
 
 # Load one stable, complete mover.ini snapshot into INI_* globals.
 # Mover Tuning rewrites this file in place, so progress must never be
@@ -541,7 +540,7 @@ load_mover_ini_snapshot() {
     [ "$before" = "$after" ] || return 1
 
     local total="" remain="" total_files="" remain_files=""
-    local current_file="" action="" key value
+    local current_file="" key value
     while IFS='=' read -r key value; do
         value="${value%\"}"
         value="${value#\"}"
@@ -551,7 +550,6 @@ load_mover_ini_snapshot() {
             TotalFilesToSecondary)  total_files="$value" ;;
             RemainFilesToSecondary) remain_files="$value" ;;
             File)                    current_file="$value" ;;
-            Action)                  action="$value" ;;
         esac
     done <<< "$snapshot"
 
@@ -574,7 +572,6 @@ load_mover_ini_snapshot() {
     INI_TOTAL_FILES="$total_files"
     INI_REMAIN_FILES="$remain_files"
     INI_CURRENT_FILE="$current_file"
-    INI_ACTION="$action"
 }
 
 # True only when mover.ini belongs to the currently running mover operation


### PR DESCRIPTION
## Summary

Restores a clean `shellcheck moverStatus.sh` run. Eight warnings had accumulated on `main` through the notification-channel work in #27, #28 and #29, and `AGENTS.md` requires the linter to stay clean. This branch is lint-only: no behavioural change, no new settings, no change to any notification payload.

## Changes

**`refactor: remove unused INI_ACTION from mover.ini parsing`** (SC2034)

`load_mover_ini_snapshot` captured the `Action` key from `mover.ini` into a global `INI_ACTION`, but no caller ever read it. The global, the corresponding local, and the `case` branch that populated them are removed. The remaining `INI_*` globals are untouched, so `get_progress` and every `PROGRESS_*` consumer are unaffected. An `Action=` line in `mover.ini` is now simply ignored, exactly as any other unrecognised key already was.

**`style: drop redundant $ from Apprise retry array indices`** (SC2004, seven occurrences)

An array subscript on the left-hand side of an assignment is already an arithmetic context, so `apprise_progress_pending[$i]=` and `apprise_completion_pending[$i]=` were flagged. The seven assignments now use the bare index. The `${apprise_progress_pending[$i]:-false}` reads are deliberately left alone: shellcheck does not flag them, and rewriting them would enlarge the diff without benefit.

## Rationale

Both warnings are cosmetic in isolation, but a linter that always reports something stops being useful for spotting real problems in later contributions. Clearing them now, ahead of the 0.1.0 release, means the next change to the script starts from a clean baseline. The `INI_ACTION` removal additionally deletes dead state rather than silencing the warning with an inline `# shellcheck disable`, which is only appropriate for genuinely unavoidable cases such as the dynamically-read `EXCLUDE_PATH_XX` settings.

## Validation

- `shellcheck moverStatus.sh` exits 0 with no output.
- `bash -n moverStatus.sh` parses cleanly.
- The two touched regions were exercised directly, since the script itself cannot run off an Unraid host. `load_mover_ini_snapshot`, `init_apprise_retry_state` and `apprise_progress_has_pending` were extracted into a harness and run against a synthetic `mover.ini` containing an `Action=` line alongside the byte and file counters:
  - the parser still returns success and publishes `INI_TOTAL_TO_SECONDARY=1000000`, `INI_REMAIN_TO_SECONDARY=250000`, `INI_TOTAL_FILES=40`, `INI_REMAIN_FILES=10` and the expected `INI_CURRENT_FILE`, with the now-unparsed `Action` line ignored;
  - `init_apprise_retry_state` seeds both pending arrays to `false` across three targets, `apprise_progress_has_pending` reports false, and it correctly reports true after a single index is marked pending, confirming the bare-index assignments address the same slots as the `${array[$i]}` reads.

## Notes

Prepared ahead of the 0.1.0 release. The `CURRENT_VERSION` bump and the tag are intentionally not part of this PR and will follow as a standalone commit on `main`, per the release procedure in `AGENTS.md`.